### PR TITLE
회원가입 UI/UX 1차 적용

### DIFF
--- a/src/app/(routes)/signin/page.tsx
+++ b/src/app/(routes)/signin/page.tsx
@@ -1,12 +1,5 @@
 import { SignInForm } from '@/feature/auth/components/SignInForm';
 
 export default async function SignInPage() {
-  return (
-    <div className='flex min-h-screen items-center justify-center'>
-      <div className='w-full max-w-md space-y-8 rounded-lg bg-white p-8 shadow-md'>
-        <h1 className='text-center text-2xl font-bold'>로그인</h1>
-        <SignInForm />
-      </div>
-    </div>
-  );
+  return <SignInForm />;
 }

--- a/src/app/(routes)/signup/page.tsx
+++ b/src/app/(routes)/signup/page.tsx
@@ -1,12 +1,5 @@
-import { SignUpForm } from '@/feature/auth/components/SignUpForm';
+import SignUpForm from '@/feature/auth/components/SignUpForm';
 
 export default async function SignUpPage() {
-  return (
-    <div className='flex min-h-screen items-center justify-center'>
-      <div className='w-full max-w-md space-y-8 rounded-lg bg-white p-8 shadow-md'>
-        <h1 className='text-center text-2xl font-bold'>회원가입</h1>
-        <SignUpForm />
-      </div>
-    </div>
-  );
+  return <SignUpForm />;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -127,6 +127,11 @@
     line-height: 2.4rem;
     font-weight: 500;
   }
+  .text-lg-small {
+    font-size: 1.6rem;
+    line-height: 2.4rem;
+    font-weight: 400;
+  }
   .text-md-bold {
     font-size: 1.4rem;
     line-height: 2rem;
@@ -142,6 +147,11 @@
     line-height: 2rem;
     font-weight: 500;
   }
+  .text-md-small {
+    font-size: 1.4rem;
+    line-height: 2rem;
+    font-weight: 400;
+  }
   .text-sm-bold {
     font-size: 1.2rem;
     line-height: 1.6rem;
@@ -156,5 +166,10 @@
     font-size: 1.2rem;
     line-height: 1.6rem;
     font-weight: 500;
+  }
+  .text-sm-small {
+    font-size: 1.2rem;
+    line-height: 1.6rem;
+    font-weight: 400;
   }
 }

--- a/src/feature/auth/actions/auth.action.ts
+++ b/src/feature/auth/actions/auth.action.ts
@@ -4,7 +4,7 @@ import { redirect } from 'next/navigation';
 import { AuthError } from 'next-auth';
 
 import { signIn } from '@/feature/auth/libs/auth';
-import { signUpSchema } from '@/feature/auth/schema/auth.schema';
+import { SignupSchema } from '@/feature/auth/schema/auth.schema';
 import { signUp } from '@/feature/auth/services/auth.service';
 
 /**
@@ -30,7 +30,7 @@ export async function signUpAction(
   formData: FormData,
 ): Promise<ActionState> {
   // 1. FormData → JS 객체로 변환 후 유효성 검사
-  const validatedFields = signUpSchema.safeParse(
+  const validatedFields = SignupSchema.safeParse(
     Object.fromEntries(formData.entries()),
   );
 

--- a/src/feature/auth/components/SignInForm.tsx
+++ b/src/feature/auth/components/SignInForm.tsx
@@ -11,29 +11,54 @@ import { Label } from '@/shared/components/ui/label';
 function SubmitButton() {
   const { pending } = useFormStatus();
   return (
-    <Button type='submit' className='w-full' disabled={pending}>
+    <Button
+      variant='primary'
+      size='sm'
+      type='submit'
+      disabled={pending}
+      className='w-full px-10 py-3'
+    >
       {pending ? '로그인 중...' : '로그인'}
     </Button>
   );
 }
 
+const KakaoBtn = () => {
+  return (
+    <Button
+      variant='primary'
+      size='sm'
+      className='w-full px-10 py-3 bg-yellow-400'
+    >
+      카카오 로그인하기
+    </Button>
+  );
+};
+
 export function SignInForm() {
   const [state, formAction] = useActionState(signInAction, null);
 
   return (
-    <form action={formAction} className='space-y-6'>
-      <div className='space-y-2'>
-        <Label htmlFor='email'>이메일</Label>
-        <Input id='email' name='email' type='email' required />
+    <div className='flex min-h-screen items-center justify-center'>
+      <div className='w-full max-w-[400px] space-y-8 rounded-lg bg-white p-8 shadow-md'>
+        <form action={formAction} className='space-y-6'>
+          <div className='space-y-2'>
+            <Label htmlFor='email'>이메일</Label>
+            <Input id='email' name='email' type='email' required />
+          </div>
+          <div className='space-y-2'>
+            <Label htmlFor='password'>비밀번호</Label>
+            <Input id='password' name='password' type='password' required />
+          </div>
+          {state?.message && (
+            <p className='text-destructive text-sm font-medium'>
+              {state.message}
+            </p>
+          )}
+          <SubmitButton />
+          <KakaoBtn />
+        </form>
       </div>
-      <div className='space-y-2'>
-        <Label htmlFor='password'>비밀번호</Label>
-        <Input id='password' name='password' type='password' required />
-      </div>
-      {state?.message && (
-        <p className='text-destructive text-sm font-medium'>{state.message}</p>
-      )}
-      <SubmitButton />
-    </form>
+    </div>
   );
 }

--- a/src/feature/auth/components/SignUpForm.tsx
+++ b/src/feature/auth/components/SignUpForm.tsx
@@ -1,60 +1,147 @@
 'use client';
 
-import { useActionState } from 'react';
+import { startTransition, useActionState } from 'react';
 import { useFormStatus } from 'react-dom';
-
 import { signUpAction } from '@/feature/auth/actions/auth.action';
 import { Button } from '@/shared/components/ui/button';
 import { Input } from '@/shared/components/ui/input';
-import { Label } from '@/shared/components/ui/label';
+import Link from 'next/link';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  SignupSchema,
+  SignUpFormData,
+} from '@/feature/auth/schema/auth.schema';
 
-function SubmitButton() {
+const SubmitButton = () => {
   const { pending } = useFormStatus();
+
   return (
-    <Button type='submit' className='w-full' disabled={pending}>
+    <Button
+      type='submit'
+      variant='primary'
+      size='sm'
+      className='flex w-[303px] md:w-[400px] lg:w-[500px] h-[42px] mt-4 text-md-bold px-14'
+      disabled={pending}
+    >
       {pending ? '가입 진행 중...' : '가입하기'}
     </Button>
   );
-}
+};
 
-export function SignUpForm() {
+const SignUpForm = () => {
   const [state, formAction] = useActionState(signUpAction, null);
 
-  return (
-    <form action={formAction} className='space-y-4'>
-      <div className='space-y-2'>
-        <Label htmlFor='email'>이메일</Label>
-        <Input id='email' name='email' type='email' required />
-      </div>
-      <div className='space-y-2'>
-        <Label htmlFor='nickname'>닉네임</Label>
-        <Input id='nickname' name='nickname' required maxLength={20} />
-      </div>
-      <div className='space-y-2'>
-        <Label htmlFor='password'>비밀번호</Label>
-        <Input
-          id='password'
-          name='password'
-          type='password'
-          required
-          minLength={8}
-        />
-      </div>
-      <div className='space-y-2'>
-        <Label htmlFor='passwordConfirmation'>비밀번호 확인</Label>
-        <Input
-          id='passwordConfirmation'
-          name='passwordConfirmation'
-          type='password'
-          required
-          minLength={8}
-        />
-      </div>
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<SignUpFormData>({
+    resolver: zodResolver(SignupSchema),
+    mode: 'onBlur',
+  });
 
-      {state?.message && (
-        <p className='text-destructive text-sm font-medium'>{state.message}</p>
-      )}
-      <SubmitButton />
-    </form>
+  const onSubmit = async (data: SignUpFormData) => {
+    const formData = new FormData();
+    Object.entries(data).forEach(([key, value]) => {
+      formData.append(key, value);
+    });
+    startTransition(() => {
+      formAction(formData);
+    });
+  };
+
+  return (
+    <div className='flex min-h-screen items-start justify-center pt-8 md:items-center md:pt-0'>
+      <div className='w-full max-w-[400px] md:max-w-[500px] lg:max-w-[600px] space-y-8 rounded-lg bg-white p-8 md:p-12 lg:p-16'>
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className='flex flex-col gap-5 w-full px-4'
+        >
+          <div>
+            <label className='text-md-bold md:text-lg-bold lg:text-2lg-bold'>
+              이메일
+            </label>
+            <Input
+              {...register('email')}
+              type='email'
+              placeholder='whyne@email.com'
+              className='w-[303px] text-lg-small md:w-[400px] lg:w-[500px] h-[42px] md:h-[52px] rounded-full border px-5 mt-1'
+            />
+            {errors.email && (
+              <p className='text-sm-small text-primary md:text-md-small lg:text-md-small pt-2'>
+                {errors.email.message}
+              </p>
+            )}
+          </div>
+          <div>
+            <label className='text-md-bold md:text-lg-bold lg:text-2lg-bold'>
+              닉네임
+            </label>
+            <Input
+              {...register('nickname')}
+              placeholder='whyne'
+              className='w-[303px] text-lg-small md:w-[400px] lg:w-[500px] h-[42px] md:h-[52px] rounded-full border px-5 mt-1'
+            />
+            {errors.nickname && (
+              <p className='text-sm-small text-primary md:text-md-small lg:text-md-small pt-2'>
+                {errors.nickname.message}
+              </p>
+            )}
+          </div>
+          <div>
+            <label className='text-md-bold md:text-lg-bold lg:text-2lg-bold'>
+              비밀번호
+            </label>
+            <Input
+              {...register('password')}
+              type='password'
+              placeholder='영문, 숫자, 특수문자(!@#$%^&*) 입력'
+              className='w-[303px] text-lg-small md:w-[400px] lg:w-[500px] h-[42px] md:h-[52px] rounded-full border px-5 mt-1'
+            />
+            {errors.password && (
+              <p className='text-sm-small text-primary md:text-md-small lg:text-md-small pt-2'>
+                {errors.password.message}
+              </p>
+            )}
+          </div>
+          <div>
+            <label className='text-md-bold md:text-lg-bold lg:text-2lg-bold'>
+              비밀번호 확인
+            </label>
+            <Input
+              {...register('passwordConfirmation')}
+              type='password'
+              placeholder='비밀번호 확인'
+              className='w-[303px] text-lg-small md:w-[400px] lg:w-[500px] h-[42px] md:h-[52px] rounded-full border px-5 mt-1'
+            />
+            {errors.passwordConfirmation && (
+              <p className='text-sm-small text-primary md:text-md-small lg:text-md-small pt-2'>
+                {errors.passwordConfirmation.message}
+              </p>
+            )}
+          </div>
+          <SubmitButton />
+          {state?.message && (
+            <p className='text-destructive text-sm font-medium'>
+              {state.message}
+            </p>
+          )}
+        </form>
+        <div className='flex flex-row items-center justify-center gap-x-4 mt-2'>
+          <span className='text-secondary text-md-small'>
+            계정이 이미 있으신가요?
+          </span>
+          <Link
+            href='/signin'
+            className='text-primary underline text-md-regular'
+          >
+            로그인 하러가기
+          </Link>
+        </div>
+      </div>
+    </div>
   );
-}
+};
+
+export default SignUpForm;

--- a/src/feature/auth/schema/auth.schema.ts
+++ b/src/feature/auth/schema/auth.schema.ts
@@ -9,7 +9,10 @@ import { z } from 'zod';
  *
  * 예시: "user@example.com" → ✅, "abc" → ❌ "이메일 형식으로 작성해주세요."
  */
-export const emailSchema = z.string().email('이메일 형식으로 작성해주세요.');
+export const emailSchema = z
+  .string()
+  .min(1, '이메일은 필수 입력입니다.')
+  .email('이메일 형식으로 작성해주세요.');
 
 /**
  * 비밀번호 유효성 검사 스키마
@@ -27,9 +30,13 @@ export const passwordSchema = z
   .min(1, '비밀번호는 필수 입력입니다.') // 공백 입력 방지
   .min(8, '비밀번호는 최소 8자 이상힙니다.') // 보안 강화
   .regex(
-    /^[a-zA-Z0-9!@#$%^&*]+$/,
+    /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,}$/,
     '비밀번호는 숫자, 영문, 특수문자로만 가능합니다.', // 허용된 문자 외 입력 방지
   );
+
+export const passwordConfirmationSchema = z
+  .string()
+  .min(1, '비밀번호 확인을 입력해주세요.');
 
 /**
  * 닉네임 유효성 검사 스키마
@@ -67,12 +74,12 @@ export const signInSchema = z.object({
  *
  * ⚠️ refine은 객체 수준에서 커스텀 검증할 때 사용 (단일 필드 이상 연관 검증에 유리)
  */
-export const signUpSchema = z
+export const SignupSchema = z
   .object({
     email: emailSchema,
     nickname: nicknameSchema,
     password: passwordSchema,
-    passwordConfirmation: z.string().min(1, '비밀번호 확인을 입력해주세요.'),
+    passwordConfirmation: passwordConfirmationSchema,
   })
   .refine((data) => data.password === data.passwordConfirmation, {
     message: '비밀번호가 일치하지 않습니다.', // 불일치 시 사용자 피드백
@@ -105,4 +112,4 @@ export type SignInFormData = z.infer<typeof signInSchema>;
  *   passwordConfirmation: string;
  * }
  */
-export type SignUpFormData = z.infer<typeof signUpSchema>;
+export type SignUpFormData = z.infer<typeof SignupSchema>;

--- a/src/shared/components/ui/button.tsx
+++ b/src/shared/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/shared/libs/utils/cn';
 
 // destructive, outline, ghost, link 고려
 const buttonVariants = cva(
-  'items-justify-center rounded-full cursor-pointer disabled:cursor-not-allowed',
+  'items-center justify-center rounded-full cursor-pointer disabled:cursor-not-allowed',
   {
     variants: {
       variant: {


### PR DESCRIPTION
## ✨ 요약 (Summary)

<!-- 어떤 작업을 했는지 한두 문장으로 요약해 주세요. -->

회원가입 로직과 반응형 대응을 진행했습니다.

## 🔗 관련 이슈 (Related Issues)

- closes #9 

## 💡 주요 변경 사항 (Changes)

- 반응형 대응 (md/lg)
- 인증 관련 로직 연결
- 스키마 일부 수정

## 📸 스크린샷 (Screenshots)

<!-- 시각적 변경이 있다면 Before/After 형식으로 첨부해 주세요. -->
아래와 같은 url로 테스트 진행하였습니다.
`확인 url: http://localhost:3000/signup`

우선 1차적으로 스타일링을 진행하였습니다. 피드백 이후 수정점이 있다면 수정 예정입니다.

[PC]
<img width="1027" alt="image" src="https://github.com/user-attachments/assets/2a33595c-a52f-48f8-a8e9-73af0226c06d" />


<br>

[tablet]
<img width="766" alt="image" src="https://github.com/user-attachments/assets/5b14ab4f-137f-44f6-9786-1e961cbb90dc" />

<br>

[mobile]
<img width="378" alt="image" src="https://github.com/user-attachments/assets/7edba8fe-40d2-447c-a8e6-78bd591e71a6" />



## ✅ 체크리스트 (Checklist)

- [x] 본인이 작성한 코드를 스스로 검토했습니다.
- [x] 팀의 코딩 컨벤션을 준수했습니다.
- [x] 문서(README, 주석 등)를 적절히 수정하거나 추가했습니다.
- [x] 필요한 경우 테스트 코드를 작성하거나 기존 테스트가 통과하는지 확인했습니다.
- [x] 기능 변경이 기존 흐름에 영향을 주지 않도록 검토했습니다.

## 🙇🏻 리뷰어에게 (For Reviewers)

<!-- 리뷰어가 참고하면 좋을 사항, 중점적으로 봐줬으면 하는 포인트 등 -->

- 회원가입 폼에 label에 반응형 대응을 했는데(sm, md, lg일때 폰트 유틸리티 다르게 설정.), 로컬에서는 브라우저 사이즈를 바꿔도 크기 변경이 되지 않습니다. 이유를 찾지 못했습니다..
- 스프린트1 끝나고 qa때 피드백 받은 요소를 이후 수정 예정입니다.
