### PR TITLE
Feat/auth ux spinner focus - auth ux 수정 

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -51,7 +51,7 @@
   }
 
   .txt-4xl-bold {
-    fonfontt-size: 4rem;
+    font-size: 4rem;
     line-height: 4.8rem;
     font-weight: 700;
   }

--- a/src/feature/auth/components/ErrorMessage.tsx
+++ b/src/feature/auth/components/ErrorMessage.tsx
@@ -8,7 +8,9 @@ interface ErrorMessageProps {
   message?: string;
 }
 
-const ERROR_MESSAGE_STYLE = 'text-destructive text-sm font-medium';
+//const ERROR_MESSAGE_STYLE = 'text-destructive text-sm font-medium';
+const ERROR_MESSAGE_STYLE =
+  'text-sm-small text-primary md:text-md-small lg:text-md-small pt-2';
 
 const ErrorMessage = ({ message }: ErrorMessageProps) => {
   if (!message) return null;

--- a/src/feature/auth/components/SignInForm.tsx
+++ b/src/feature/auth/components/SignInForm.tsx
@@ -20,6 +20,7 @@ import {
   type SignInFormData,
   signInSchema,
 } from '@/feature/auth/schema/auth.schema';
+import Spinner from '@/shared/components/common/spinner';
 
 import { Button } from '../../../shared/components/ui/button';
 import AuthLink from './AuthLink';
@@ -29,8 +30,7 @@ import FormField from './FormField';
 
 const SignInForm: () => JSX.Element = () => {
   const [state, formAction] = useActionState(signInAction, null);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [_isPending, startTransition] = useTransition();
+  const [isPending, startTransition] = useTransition();
 
   const {
     register,
@@ -53,44 +53,54 @@ const SignInForm: () => JSX.Element = () => {
   };
 
   return (
-    <form
-      onSubmit={handleSubmit(onSubmit)}
-      className='flex-center flex h-[67.9rem] w-[34.3rem] flex-col gap-5 px-4 md:h-[76.2rem] md:w-[49.6rem] lg:h-[79.4rem] lg:w-[50rem]'
-    >
-      <FormField<SignInFormData>
-        label='이메일'
-        name='email'
-        type='email'
-        placeholder='이메일 입력'
-        register={register}
-        errors={errors}
-      />
-
-      <FormField<SignInFormData>
-        label='비밀번호'
-        name='password'
-        type='password'
-        placeholder='비밀번호 입력'
-        register={register}
-        errors={errors}
-      />
-
-      <SubmitButton>로그인</SubmitButton>
-      <Button
-        size='full'
-        className='bg-[#FFDB00] !text-black hover:bg-[#FFDB00]/60'
+    <>
+      {isPending && (
+        <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/70'>
+          <div className='flex flex-col items-center gap-4 rounded-lg bg-white p-8 shadow-lg'>
+            <Spinner size='large' color='primary' />
+            <span className='text-primary text-xl font-bold'>처리 중...</span>
+          </div>
+        </div>
+      )}
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className='flex-center flex h-[67.9rem] w-[34.3rem] flex-col gap-5 px-4 md:h-[76.2rem] md:w-[49.6rem] lg:h-[79.4rem] lg:w-[50rem]'
       >
-        카카오로 시작하기
-      </Button>
+        <FormField<SignInFormData>
+          label='이메일'
+          name='email'
+          type='email'
+          placeholder='이메일 입력'
+          register={register}
+          errors={errors}
+        />
 
-      {state?.message && <ErrorMessage message={state.message} />}
+        <FormField<SignInFormData>
+          label='비밀번호'
+          name='password'
+          type='password'
+          placeholder='비밀번호 입력'
+          register={register}
+          errors={errors}
+        />
 
-      <AuthLink
-        label='계정이 없으신가요?'
-        linkText='회원가입하기'
-        href='/signup'
-      />
-    </form>
+        <SubmitButton isPending={isPending}>로그인</SubmitButton>
+        <Button
+          size='full'
+          className='bg-[#FFDB00] !text-black hover:bg-[#FFDB00]/60'
+        >
+          카카오로 시작하기
+        </Button>
+
+        {state?.message && <ErrorMessage message={state.message} />}
+
+        <AuthLink
+          label='계정이 없으신가요?'
+          linkText='회원가입하기'
+          href='/signup'
+        />
+      </form>
+    </>
   );
 };
 

--- a/src/feature/auth/components/SignUpForm.tsx
+++ b/src/feature/auth/components/SignUpForm.tsx
@@ -19,6 +19,7 @@ import {
   SignUpFormData,
   SignupSchema,
 } from '@/feature/auth/schema/auth.schema';
+import Spinner from '@/shared/components/common/spinner';
 
 import AuthLink from './AuthLink';
 import SubmitButton from './buttons/SubmitButton';
@@ -27,8 +28,7 @@ import FormField from './FormField';
 
 const SignUpForm: () => JSX.Element = () => {
   const [state, formAction] = useActionState(signUpAction, null);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [_isPending, startTransition] = useTransition();
+  const [isPending, startTransition] = useTransition();
 
   const {
     register,
@@ -52,54 +52,64 @@ const SignUpForm: () => JSX.Element = () => {
   };
 
   return (
-    <form
-      onSubmit={handleSubmit(onSubmit)}
-      className='flex-center flex h-[67.9rem] w-[34.3rem] flex-col gap-5 px-4 md:h-[76.2rem] md:w-[49.6rem] lg:h-[79.4rem] lg:w-[50rem]'
-    >
-      <FormField
-        label='이메일'
-        name='email'
-        type='email'
-        placeholder='whyne@email.com'
-        register={register}
-        errors={errors}
-      />
+    <>
+      {isPending && (
+        <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/70'>
+          <div className='flex flex-col items-center gap-4 rounded-lg bg-white p-8 shadow-lg'>
+            <Spinner size='large' color='primary' />
+            <span className='text-primary text-xl font-bold'>처리 중...</span>
+          </div>
+        </div>
+      )}
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className='flex-center flex h-[67.9rem] w-[34.3rem] flex-col gap-5 px-4 md:h-[76.2rem] md:w-[49.6rem] lg:h-[79.4rem] lg:w-[50rem]'
+      >
+        <FormField
+          label='이메일'
+          name='email'
+          type='email'
+          placeholder='whyne@email.com'
+          register={register}
+          errors={errors}
+        />
 
-      <FormField
-        label='닉네임'
-        name='nickname'
-        type='text'
-        placeholder='whyne'
-        register={register}
-        errors={errors}
-      />
+        <FormField
+          label='닉네임'
+          name='nickname'
+          type='text'
+          placeholder='whyne'
+          register={register}
+          errors={errors}
+        />
 
-      <FormField
-        label='비밀번호'
-        name='password'
-        type='password'
-        placeholder='영문, 숫자, 특수문자(!@#$%^&*) 제한'
-        register={register}
-        errors={errors}
-      />
+        <FormField
+          label='비밀번호'
+          name='password'
+          type='password'
+          placeholder='영문, 숫자, 특수문자(!@#$%^&*) 제한'
+          register={register}
+          errors={errors}
+        />
 
-      <FormField
-        label='비밀번호 확인'
-        name='passwordConfirmation'
-        type='password'
-        placeholder='비밀번호 확인'
-        register={register}
-        errors={errors}
-      />
+        <FormField
+          label='비밀번호 확인'
+          name='passwordConfirmation'
+          type='password'
+          placeholder='비밀번호 확인'
+          register={register}
+          errors={errors}
+        />
 
-      <SubmitButton>가입하기</SubmitButton>
-      <ErrorMessage message={state?.message} />
-      <AuthLink
-        label='계정이 이미 있으신가요?'
-        linkText='로그인 하러가기'
-        href='/signin'
-      />
-    </form>
+        <SubmitButton isPending={isPending}>가입하기</SubmitButton>
+        <ErrorMessage message={state?.message} />
+        <AuthLink
+          label='계정이 이미 있으신가요?'
+          linkText='로그인 하러가기'
+          href='/signin'
+        />
+      </form>
+    </>
   );
 };
 

--- a/src/feature/auth/components/buttons/SubmitButton.tsx
+++ b/src/feature/auth/components/buttons/SubmitButton.tsx
@@ -6,21 +6,18 @@
 
 'use client';
 
-import { useFormStatus } from 'react-dom';
-
 import { Button } from '@/shared/components/ui/button';
 
 interface SubmitButtonProps {
   children: React.ReactNode;
   className?: string;
+  isPending?: boolean;
 }
 
-const SubmitButton = ({ children }: SubmitButtonProps) => {
-  const { pending } = useFormStatus();
-
+const SubmitButton = ({ children, isPending }: SubmitButtonProps) => {
   return (
-    <Button type='submit' variant='primary' size='full' disabled={pending}>
-      {pending ? '처리 중...' : children}
+    <Button type='submit' variant='primary' size='full' disabled={isPending}>
+      {children}
     </Button>
   );
 };


### PR DESCRIPTION
## ✨ 요약 (Summary)

로딩 스피너 연결(로그인, 회원가입), 에러메시지 시 해당 인풋창에 자동 포커스(회원가입)

## 🔗 관련 이슈 (Related Issues)

- closes #37 

## 💡 주요 변경 사항 (Changes)

- 가입하기 또는 로그인 시 그 사이 동안 로딩 ui를 연결 (스타일은 구글링으로 가져와서 적용했습니다.)
- useTransition()함수를 사용하여 서버 액션의 진행상태(isPending)를 관리하였습니다.
(https://ko.react.dev/reference/react/useTransition)
- 이미 가입한 유저가 동일한 이메일로 재 가입 시, ErrorMessage 컴포넌트를 보여주도록 수정했습니다. (+ 해당 인풋창에 자동 포커스)

## 📸 스크린샷 (Screenshots)

<!-- 시각적 변경이 있다면 Before/After 형식으로 첨부해 주세요. -->

| Before | After |
| ------ | ----- |
|        |       |

> ※ UI 변화가 없다면 이 항목은 생략 가능합니다.

## ✅ 체크리스트 (Checklist)

- [x] 본인이 작성한 코드를 스스로 검토했습니다.
- [x] 팀의 코딩 컨벤션을 준수했습니다.
- [x] 문서(README, 주석 등)를 적절히 수정하거나 추가했습니다.
- [x] 필요한 경우 테스트 코드를 작성하거나 기존 테스트가 통과하는지 확인했습니다.
- [x] 기능 변경이 기존 흐름에 영향을 주지 않도록 검토했습니다.

## 🙇🏻 리뷰어에게 (For Reviewers)

<!-- 리뷰어가 참고하면 좋을 사항, 중점적으로 봐줬으면 하는 포인트 등 -->
일단 asap으로 개발했습니다. ㅎㅎ.....