### PR TITLE
Feat/review card

### DIFF
--- a/src/app/card/page.tsx
+++ b/src/app/card/page.tsx
@@ -1,7 +1,7 @@
 import { auth } from '@/feature/auth';
 import DetailCard from '@/feature/wines/components/card/DetailCard';
 import MonthlyCard from '@/feature/wines/components/card/MonthlyCard';
-import { ReviewCard } from '@/feature/wines/components/card/ReviewCard';
+import ReviewCard from '@/feature/wines/components/card/ReviewCard';
 import WineCard from '@/feature/wines/components/card/WineCard';
 import { mockWine } from '@/feature/wines/mocks';
 

--- a/src/app/card/page.tsx
+++ b/src/app/card/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from '@/feature/auth';
 import DetailCard from '@/feature/wines/components/card/DetailCard';
 import MonthlyCard from '@/feature/wines/components/card/MonthlyCard';
+import MyReviewCard from '@/feature/wines/components/card/MyReviewCard';
 import ReviewCard from '@/feature/wines/components/card/ReviewCard';
 import WineCard from '@/feature/wines/components/card/WineCard';
 import { mockWine } from '@/feature/wines/mocks';
@@ -13,10 +14,11 @@ const CardPage = async () => {
     <div className='flex flex-col gap-6'>
       <MonthlyCard wine={mockWine} />
       <WineCard wine={mockWine} />
-      {currentUser && <DetailCard wine={mockWine} currentUser={currentUser} />}
-      {currentUser && (
-        <ReviewCard review={mockWine.recentReview} currentUser={currentUser} />
-      )}
+      <DetailCard wine={mockWine} currentUser={currentUser!} />
+
+      <ReviewCard review={mockWine.recentReview} currentUser={currentUser!} />
+
+      <MyReviewCard />
     </div>
   );
 };

--- a/src/app/card/page.tsx
+++ b/src/app/card/page.tsx
@@ -4,7 +4,7 @@ import MonthlyCard from '@/feature/wines/components/card/MonthlyCard';
 import MyReviewCard from '@/feature/wines/components/card/MyReviewCard';
 import ReviewCard from '@/feature/wines/components/card/ReviewCard';
 import WineCard from '@/feature/wines/components/card/WineCard';
-import { mockWine } from '@/feature/wines/mocks';
+import { mockReview, mockWine } from '@/feature/wines/mocks';
 
 const CardPage = async () => {
   const session = await auth();
@@ -18,7 +18,7 @@ const CardPage = async () => {
 
       <ReviewCard review={mockWine.recentReview} currentUser={currentUser!} />
 
-      <MyReviewCard />
+      <MyReviewCard review={mockReview.list[0]} />
     </div>
   );
 };

--- a/src/feature/reviews/schemas/reviews.schema.ts
+++ b/src/feature/reviews/schemas/reviews.schema.ts
@@ -31,8 +31,8 @@ export const myReviewWithWineSchema = myReviewItemSchema.extend({
     name: nonEmptyStringSchema,
     region: nonEmptyStringSchema,
     image: urlSchema,
-    price: positiveNumberSchema,
-    avgRating: positiveNumberSchema,
+    price: nonNegativeNumberSchema,
+    avgRating: nonNegativeNumberSchema,
     type: WineTypeEnumSchema,
   }),
 });

--- a/src/feature/reviews/schemas/reviews.schema.ts
+++ b/src/feature/reviews/schemas/reviews.schema.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+
+import {
+  wineDetailReviewSchema,
+  WineTypeEnumSchema,
+} from '@/feature/wines/schema/wine.schema';
+import {
+  nonEmptyStringSchema,
+  nonNegativeNumberSchema,
+  positiveNumberSchema,
+  urlSchema,
+} from '@/shared/schemas/common.schema';
+
+// --- 6. 내 리뷰 목록 조회: GET /{teamId}/users/me/reviews ---
+
+/**
+ * @description [응답] 내 리뷰 목록 조회 API의 전체 응답 객체를 검증합니다.
+ */
+export const getMyReviewResponseSchema = z.object({
+  list: z.array(wineDetailReviewSchema),
+  totalCount: nonNegativeNumberSchema,
+  nextCursor: positiveNumberSchema.nullable(),
+});
+
+/**
+ * @description 와인 정보가 포함된 내 리뷰 아이템 스키마입니다.
+ * 클라이언트에서 데이터를 조합한 후 사용됩니다.
+ */
+export const myReviewWithWineSchema = wineDetailReviewSchema.extend({
+  wine: z.object({
+    id: positiveNumberSchema,
+    name: nonEmptyStringSchema,
+    image: urlSchema,
+    type: WineTypeEnumSchema,
+  }),
+});
+
+export type GetMyReviewResponse = z.infer<typeof getMyReviewResponseSchema>;
+export type MyReviewWithWine = z.infer<typeof myReviewWithWineSchema>;

--- a/src/feature/reviews/schemas/reviews.schema.ts
+++ b/src/feature/reviews/schemas/reviews.schema.ts
@@ -14,26 +14,38 @@ import {
 // --- 6. 내 리뷰 목록 조회: GET /{teamId}/users/me/reviews ---
 
 /**
- * @description [응답] 내 리뷰 목록 조회 API의 전체 응답 객체를 검증합니다.
+ * @description 내 리뷰 목록에서 사용되는 개별 리뷰 스키마입니다.
+ * isLiked 필드가 제외된 버전입니다.
  */
-export const getMyReviewResponseSchema = z.object({
-  list: z.array(wineDetailReviewSchema),
-  totalCount: nonNegativeNumberSchema,
-  nextCursor: positiveNumberSchema.nullable(),
+export const myReviewItemSchema = wineDetailReviewSchema.omit({
+  isLiked: true,
 });
 
 /**
  * @description 와인 정보가 포함된 내 리뷰 아이템 스키마입니다.
  * 클라이언트에서 데이터를 조합한 후 사용됩니다.
  */
-export const myReviewWithWineSchema = wineDetailReviewSchema.extend({
+export const myReviewWithWineSchema = myReviewItemSchema.extend({
   wine: z.object({
     id: positiveNumberSchema,
     name: nonEmptyStringSchema,
+    region: nonEmptyStringSchema,
     image: urlSchema,
+    price: positiveNumberSchema,
+    avgRating: positiveNumberSchema,
     type: WineTypeEnumSchema,
   }),
 });
 
+/**
+ * @description [응답] 내 리뷰 목록 조회 API의 전체 응답 객체를 검증합니다.
+ */
+export const getMyReviewResponseSchema = z.object({
+  list: z.array(myReviewWithWineSchema),
+  totalCount: nonNegativeNumberSchema,
+  nextCursor: positiveNumberSchema.nullable(),
+});
+
 export type GetMyReviewResponse = z.infer<typeof getMyReviewResponseSchema>;
 export type MyReviewWithWine = z.infer<typeof myReviewWithWineSchema>;
+export type MyReviewItem = z.infer<typeof myReviewItemSchema>;

--- a/src/feature/wines/components/button/CardDropdownMenu.tsx
+++ b/src/feature/wines/components/button/CardDropdownMenu.tsx
@@ -23,9 +23,9 @@ const CardDropdownMenu = () => {
     <DropdownMenu>
       <DropdownMenuTrigger asChild className={DROPDOWN_STYLES.trigger}>
         <EllipsisVertical
-          size={28}
           color='#ac271e'
           className='h-[2.4rem] w-[2.4rem] md:h-[2.8rem] md:w-[2.8rem]'
+          aria-label='카드 메뉴 열기'
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent className={DROPDOWN_STYLES.content}>

--- a/src/feature/wines/components/button/CardDropdownMenu.tsx
+++ b/src/feature/wines/components/button/CardDropdownMenu.tsx
@@ -22,7 +22,11 @@ const CardDropdownMenu = () => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild className={DROPDOWN_STYLES.trigger}>
-        <EllipsisVertical size={28} color='#ac271e' />
+        <EllipsisVertical
+          size={28}
+          color='#ac271e'
+          className='h-[2.4rem] w-[2.4rem] md:h-[2.8rem] md:w-[2.8rem]'
+        />
       </DropdownMenuTrigger>
       <DropdownMenuContent className={DROPDOWN_STYLES.content}>
         <DropdownMenuItem className={DROPDOWN_STYLES.menuItem}>

--- a/src/feature/wines/components/card/MonthlyCard.tsx
+++ b/src/feature/wines/components/card/MonthlyCard.tsx
@@ -20,7 +20,7 @@ const MonthlyCard = ({ wine }: { wine: WineSummary }) => {
         </figure>
         <article className='flex flex-2 flex-col justify-center gap-2'>
           <h2 className='text-[2.8rem] font-bold md:text-[3.6rem]'>
-            {avgRating}
+            {avgRating.toFixed(1)}
           </h2>
           <StarRating value={avgRating} readOnly />
           <p className='mt-2 line-clamp-3 text-[1.2rem] md:line-clamp-4'>

--- a/src/feature/wines/components/card/MyReviewCard.tsx
+++ b/src/feature/wines/components/card/MyReviewCard.tsx
@@ -1,0 +1,36 @@
+import CardDropdownMenu from '@/feature/wines/components/button/CardDropdownMenu';
+// import { WineDetailReview } from '@/feature/wines/schema/wine.schema';
+import { Card, CardContent } from '@/shared/components/ui/card';
+
+const MyReviewCard = () => {
+  return (
+    <Card className='w-[34.3rem] px-[1rem] py-[1.6rem] md:w-[70.4rem] md:px-[4rem] md:py-[2.4rem] lg:w-[80rem]'>
+      <CardContent className='flex flex-col gap-4'>
+        <div className='flex justify-between'>
+          <div className='flex items-center gap-2'>
+            <p className='bg-secondary text-primary rounded-full px-[1rem] py-[0.6rem] text-[1.4rem] font-semibold md:px-[1.5rem] md:text-[1.8rem]'>
+              ★ 5.0
+            </p>
+            <p className='text-[1.4rem] font-medium md:text-[1.6rem]'>작성일</p>
+          </div>
+          <div className='flex items-center'>
+            <CardDropdownMenu />
+          </div>
+        </div>
+        <div className='flex flex-col gap-2'>
+          <h2 className='text-[1.4rem] font-semibold md:text-[1.6rem]'>
+            Sentinal Carbernet Sauvignon 2016
+          </h2>
+          <p className='text-[1.4rem] font-normal md:text-[1.6rem]'>
+            Deep maroon color, tasting notes of blackberry, dark chocolate,
+            plum. Super jammy and bold with some smoky after notes. Big flavor.
+            Amazing value (would pay three times the price for it), well
+            balanced flavor. Could drink all day everyday with or without food.
+            I need more immediately.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+export default MyReviewCard;

--- a/src/feature/wines/components/card/MyReviewCard.tsx
+++ b/src/feature/wines/components/card/MyReviewCard.tsx
@@ -1,32 +1,33 @@
+import { MyReviewWithWine } from '@/feature/reviews/schemas/reviews.schema';
+import { formatRelativeTime } from '@/feature/reviews/utils/formatRelativeTime';
 import CardDropdownMenu from '@/feature/wines/components/button/CardDropdownMenu';
-// import { WineDetailReview } from '@/feature/wines/schema/wine.schema';
 import { Card, CardContent } from '@/shared/components/ui/card';
 
-const MyReviewCard = () => {
+// TODO: 드롭다운 메뉴 수정 삭제 추가 필요
+const MyReviewCard = ({ review }: { review: MyReviewWithWine }) => {
+  const { wine, rating, createdAt, content } = review;
+  const { name } = wine;
+
   return (
     <Card className='w-[34.3rem] px-[1rem] py-[1.6rem] md:w-[70.4rem] md:px-[4rem] md:py-[2.4rem] lg:w-[80rem]'>
       <CardContent className='flex flex-col gap-4'>
         <div className='flex justify-between'>
           <div className='flex items-center gap-2'>
             <p className='bg-secondary text-primary rounded-full px-[1rem] py-[0.6rem] text-[1.4rem] font-semibold md:px-[1.5rem] md:text-[1.8rem]'>
-              ★ 5.0
+              ★ {rating.toFixed(1)}
             </p>
-            <p className='text-[1.4rem] font-medium md:text-[1.6rem]'>작성일</p>
+            <p className='text-[1.4rem] font-medium md:text-[1.6rem]'>
+              {formatRelativeTime(createdAt)}
+            </p>
           </div>
           <div className='flex items-center'>
             <CardDropdownMenu />
           </div>
         </div>
         <div className='flex flex-col gap-2'>
-          <h2 className='text-[1.4rem] font-semibold md:text-[1.6rem]'>
-            Sentinal Carbernet Sauvignon 2016
-          </h2>
+          <h2 className='text-[1.8rem] font-semibold md:text-[2rem]'>{name}</h2>
           <p className='text-[1.4rem] font-normal md:text-[1.6rem]'>
-            Deep maroon color, tasting notes of blackberry, dark chocolate,
-            plum. Super jammy and bold with some smoky after notes. Big flavor.
-            Amazing value (would pay three times the price for it), well
-            balanced flavor. Could drink all day everyday with or without food.
-            I need more immediately.
+            {content}
           </p>
         </div>
       </CardContent>

--- a/src/feature/wines/components/card/ReviewCard.tsx
+++ b/src/feature/wines/components/card/ReviewCard.tsx
@@ -83,15 +83,13 @@ const ReviewCard = ({
           ))}
         </div>
         <div className='flex-center bg-secondary text-primary w-[6rem] self-start rounded-full px-4 py-2 text-[1.4rem] font-semibold md:w-[7.2rem] md:px-5 md:py-3 md:text-[1.6rem]'>
-          ★ {rating}
+          ★ {rating.toFixed(1)}
         </div>
       </div>
 
       {/* 펼쳐진 내용 */}
       <CollapsibleContent className='space-y-4 pt-4 text-[1.4rem] md:space-y-8 md:pt-8 md:text-[1.6rem]'>
         <p>{content}</p>
-
-        {/* 슬라이더 UI (예시용, 실제 구현은 range input 또는 UI 라이브러리 사용) */}
         <WineTasteSlider values={taste} />
       </CollapsibleContent>
       {/* 펼치기 버튼 */}

--- a/src/feature/wines/components/card/ReviewCard.tsx
+++ b/src/feature/wines/components/card/ReviewCard.tsx
@@ -16,13 +16,13 @@ import {
   CollapsibleTrigger,
 } from '@/shared/components/ui/collapsible';
 
-export function ReviewCard({
+const ReviewCard = ({
   review,
   currentUser,
 }: {
   review: ReviewDetail;
   currentUser: number;
-}) {
+}) => {
   const [open, setOpen] = useState(false);
   const {
     aroma,
@@ -102,4 +102,6 @@ export function ReviewCard({
       </CollapsibleTrigger>
     </Collapsible>
   );
-}
+};
+
+export default ReviewCard;

--- a/src/feature/wines/components/card/ReviewCard.tsx
+++ b/src/feature/wines/components/card/ReviewCard.tsx
@@ -7,7 +7,7 @@ import WineTasteSlider from '@/feature/reviews/components/wine-taste-slider';
 import { formatRelativeTime } from '@/feature/reviews/utils/formatRelativeTime';
 import CardDropdownMenu from '@/feature/wines/components/button/CardDropdownMenu';
 import LikeButton from '@/feature/wines/components/button/LikeButton';
-import { ReviewDetail } from '@/feature/wines/schema/wine.schema';
+import { WineDetailReview } from '@/feature/wines/schema/wine.schema';
 import { formatAromaType } from '@/feature/wines/utils/formatWineType';
 import UserAvatar from '@/shared/components/common/user-avatar';
 import {
@@ -20,7 +20,7 @@ const ReviewCard = ({
   review,
   currentUser,
 }: {
-  review: ReviewDetail;
+  review: WineDetailReview;
   currentUser: number;
 }) => {
   const [open, setOpen] = useState(false);

--- a/src/feature/wines/components/card/WineCard.tsx
+++ b/src/feature/wines/components/card/WineCard.tsx
@@ -49,7 +49,7 @@ const WineCard = ({ wine }: { wine: GetWinesResponse['list'][number] }) => {
               aria-label='평점 정보'
             >
               <span className='text-[2.8rem] font-extrabold md:text-[4.8rem]'>
-                {avgRating}
+                {avgRating.toFixed(1)}
               </span>
               <div className='flex flex-col items-center gap-2 md:items-start md:justify-start md:gap-4'>
                 <StarRating value={avgRating} readOnly size='md' />

--- a/src/feature/wines/mocks/index.ts
+++ b/src/feature/wines/mocks/index.ts
@@ -81,3 +81,37 @@ export const mockWine = {
     '5': 4,
   },
 };
+
+export const mockReview = {
+  list: [
+    {
+      id: 2538,
+      rating: 4,
+      lightBold: 3,
+      smoothTannic: 7,
+      drySweet: 5,
+      softAcidic: 4,
+      aroma: ['CHERRY', 'OAK', 'GRASS'] as AromaTypeEnum[],
+      content: '테스트 컨텐츠입니다. 맛이 좋아요',
+      createdAt: '2025-06-18T01:16:38.082Z',
+      updatedAt: '2025-06-18T01:16:38.082Z',
+      user: {
+        id: 1435,
+        nickname: 'jinTest',
+        image: null,
+      },
+      wine: {
+        id: 1093,
+        name: 'Château Margaux',
+        region: 'Bordeaux, France',
+        image:
+          'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Wine/user/1435/1750147721454/1.png',
+        price: 450,
+        avgRating: 4,
+        type: 'RED' as WineTypeEnum,
+      },
+    },
+  ],
+  totalCount: 1,
+  nextCursor: null,
+};

--- a/src/feature/wines/schema/wine.schema.ts
+++ b/src/feature/wines/schema/wine.schema.ts
@@ -10,8 +10,8 @@ import { z } from 'zod';
 // --- A. 기본 타입 및 열거형 스키마 (Primitives & Enums) ---
 
 const urlSchema = z.string().url().or(z.literal(''));
-const nonNegativeNumberSchema = z.number().nonnegative();
-const positiveNumberSchema = z.number().positive();
+const nonNegativeNumberSchema = z.number().nonnegative().step(0.1);
+const positiveNumberSchema = z.number().positive().step(0.1);
 const nonEmptyStringSchema = z.string().min(1);
 
 /** 와인의 종류 (RED, WHITE, SPARKLING) */

--- a/src/feature/wines/schema/wine.schema.ts
+++ b/src/feature/wines/schema/wine.schema.ts
@@ -10,8 +10,8 @@ import { z } from 'zod';
 // --- A. 기본 타입 및 열거형 스키마 (Primitives & Enums) ---
 
 const urlSchema = z.string().url().or(z.literal(''));
-const nonNegativeNumberSchema = z.number().nonnegative().step(0.1);
-const positiveNumberSchema = z.number().positive().step(0.1);
+const nonNegativeNumberSchema = z.number().nonnegative();
+const positiveNumberSchema = z.number().positive();
 const nonEmptyStringSchema = z.string().min(1);
 
 /** 와인의 종류 (RED, WHITE, SPARKLING) */
@@ -62,10 +62,10 @@ export const reviewResponseSchema = z.object({
 
 /** 와인 상세 정보에 포함되는 개별 리뷰 객체 (선호도, 맛 표현 포함) */
 export const wineDetailReviewSchema = reviewResponseSchema.extend({
-  lightBold: positiveNumberSchema.min(1).max(100),
-  smoothTannic: positiveNumberSchema.min(1).max(100),
-  drySweet: positiveNumberSchema.min(1).max(100),
-  softAcidic: positiveNumberSchema.min(1).max(100),
+  lightBold: positiveNumberSchema.min(1).max(10),
+  smoothTannic: positiveNumberSchema.min(1).max(10),
+  drySweet: positiveNumberSchema.min(1).max(10),
+  softAcidic: positiveNumberSchema.min(1).max(10),
   isLiked: z.boolean(),
 });
 
@@ -77,8 +77,8 @@ const wineBaseSchema = z.object({
   image: urlSchema,
   price: positiveNumberSchema,
   type: WineTypeEnumSchema,
-  avgRating: positiveNumberSchema,
-  reviewCount: positiveNumberSchema,
+  avgRating: nonNegativeNumberSchema,
+  reviewCount: nonNegativeNumberSchema,
   userId: positiveNumberSchema,
 });
 
@@ -139,10 +139,7 @@ export const getWinesResponseSchema = z.object({
 export const getWineDetailResponseSchema = wineBaseSchema.extend({
   recentReview: reviewResponseSchema.nullable(),
   reviews: z.array(wineDetailReviewSchema),
-  avgRatings: z.record(
-    z.enum(['1', '2', '3', '4', '5']),
-    nonNegativeNumberSchema,
-  ),
+  avgRatings: z.record(z.enum(['1', '2', '3', '4', '5']), positiveNumberSchema),
 });
 
 // --- 4. 와인 수정: PATCH /{teamId}/wines/{id} ---

--- a/src/feature/wines/schema/wine.schema.ts
+++ b/src/feature/wines/schema/wine.schema.ts
@@ -175,7 +175,7 @@ export type AromaTypeEnum = z.infer<typeof AromaTypeEnumSchema>;
 // 기존 타입들과의 호환성을 위한 alias 추가
 export type AromaType = AromaTypeEnum;
 export type WineSummary = z.infer<typeof wineBaseSchema>;
-export type ReviewDetail = z.infer<typeof wineDetailReviewSchema>;
+export type WineDetailReview = z.infer<typeof wineDetailReviewSchema>;
 
 export type CreateWineRequest = z.infer<typeof createWineRequestSchema>;
 export type CreateWineResponse = z.infer<typeof createWineResponseSchema>;


### PR DESCRIPTION
## ✨ 요약 (Summary)
마이프로필 리뷰 카드를 구현했습니다.

## 🔗 관련 이슈 (Related Issues)
- closes #96 

## 💡 주요 변경 사항 (Changes)
- 마이프로필 페이지에 사용되는 리뷰 카드를 구현했습니다.
- `users/me/review` api 기준으로 반환되는 리뷰 데이터를 props로 전달해서 사용합니다.

## 📸 스크린샷 (Screenshots)
![image](https://github.com/user-attachments/assets/4d6923b3-46c4-48f7-91b3-8b5c481e5074)
![image](https://github.com/user-attachments/assets/4ff5fba9-d80a-4877-baad-857aab3a511d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 사용자의 와인 리뷰를 보여주는 새로운 카드(MyReviewCard) 컴포넌트가 추가되었습니다.
  - 마이 리뷰 리스트를 위한 데이터 검증 및 타입 스키마가 도입되었습니다.
  - 샘플 리뷰(mockReview) 데이터가 추가되었습니다.

- **기능 개선**
  - 카드 페이지에서 사용자 정보와 상관없이 모든 카드가 항상 표시됩니다.
  - 리뷰 카드에서 평점이 소수점 한 자리로 표시됩니다.
  - 드롭다운 메뉴 아이콘이 반응형 크기로 조정되었습니다.

- **타입 및 명칭 변경**
  - 일부 타입 및 타입 별칭의 명칭이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->