### PR TITLE
fix: 중복호출되는 와인 delete api 삭제

### DIFF
--- a/src/feature/myprofile/components/WineCardList.tsx
+++ b/src/feature/myprofile/components/WineCardList.tsx
@@ -8,9 +8,8 @@
  */
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { toast } from 'sonner';
 
-import { deleteWine, getUserWines, Wine } from '@/feature/libs/api/userApi';
+import { getUserWines, Wine } from '@/feature/libs/api/userApi';
 import EditWineReviewForm from '@/feature/reviews/components/wine-review-form/EditWineReviewForm';
 import DetailCard from '@/feature/wines/components/card/DetailCard';
 import {
@@ -118,26 +117,7 @@ const WineCardList: React.FC<WineCardListProps> = ({ accessToken }) => {
 
   // 와인 삭제 핸들러 (동작은 추후 구현) 와인 삭제 후 상태 업데이트(filter)
   const handleDeleteWineClick = (wineId: number) => {
-    toast('정말로 이 와인을 삭제하시겠습니까?', {
-      action: {
-        label: '삭제',
-        onClick: () => {
-          deleteWine(wineId)
-            .then(() => {
-              setWines((prev) => prev.filter((wine) => wine.id !== wineId));
-              toast.success('와인이 삭제되었습니다.');
-            })
-            .catch((error) => {
-              console.error('와인 삭제 실패:', error);
-              toast.error('와인 삭제에 실패했습니다.');
-            });
-        },
-      },
-      cancel: {
-        label: '취소',
-        onClick: () => {},
-      },
-    });
+    setWines((prev) => prev.filter((wine) => wine.id !== wineId));
   };
 
   useEffect(() => {


### PR DESCRIPTION
## ✨ 요약 (Summary)

<!-- 어떤 작업을 했는지 한두 문장으로 요약해 주세요. -->

예: 회원가입 시 이메일 인증 기능을 추가했습니다.

## 🔗 관련 이슈 (Related Issues)

- closes #이슈번호

## 💡 주요 변경 사항 (Changes)

- 이메일 인증 API 연동
- 인증 여부에 따른 로그인 제한 처리
- 인증 대기 시 경고 메시지 추가

## 📸 스크린샷 (Screenshots)

<!-- 시각적 변경이 있다면 Before/After 형식으로 첨부해 주세요. -->

| Before | After |
| ------ | ----- |
|        |       |

> ※ UI 변화가 없다면 이 항목은 생략 가능합니다.

## ✅ 체크리스트 (Checklist)

- [ ] 본인이 작성한 코드를 스스로 검토했습니다.
- [ ] 팀의 코딩 컨벤션을 준수했습니다.
- [ ] 문서(README, 주석 등)를 적절히 수정하거나 추가했습니다.
- [ ] 필요한 경우 테스트 코드를 작성하거나 기존 테스트가 통과하는지 확인했습니다.
- [ ] 기능 변경이 기존 흐름에 영향을 주지 않도록 검토했습니다.

## 🙇🏻 리뷰어에게 (For Reviewers)

<!-- 리뷰어가 참고하면 좋을 사항, 중점적으로 봐줬으면 하는 포인트 등 -->

- ❓ 인증 성공/실패 분기 처리가 자연스러운지 확인 부탁드립니다.
- 💬 API 응답 속도 이슈가 있어 개선 아이디어 있으면 제안 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 와인 삭제 시 사용자 확인 및 알림 없이 즉시 목록에서 삭제되도록 변경되었습니다.  
  - 삭제와 관련된 오류 처리 및 성공 알림이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->